### PR TITLE
Add VS Code PlatformIO build support for DriverSample

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -410,6 +410,9 @@ FodyWeavers.xsd
 # Built Visual Studio Code Extensions
 *.vsix
 
+# PlatformIO build directory
+**/.pio/
+
 # Windows Installer files from build outputs
 *.cab
 *.msi

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "platformio.platformio-ide"
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,61 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "PIO Build (DriverSample)",
+            "type": "shell",
+            "command": "platformio",
+            "args": [
+                "run",
+                "--project-dir",
+                "examples/DriverSample"
+            ],
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "problemMatcher": [
+                "$platformio"
+            ],
+            "presentation": {
+                "clear": true,
+                "panel": "shared"
+            }
+        },
+        {
+            "label": "PIO Upload (DriverSample)",
+            "type": "shell",
+            "command": "platformio",
+            "args": [
+                "run",
+                "--target",
+                "upload",
+                "--project-dir",
+                "examples/DriverSample"
+            ],
+            "group": {
+                "kind": "build",
+                "isDefault": false
+            },
+            "problemMatcher": [
+                "$platformio"
+            ],
+            "presentation": {
+                "clear": true,
+                "panel": "shared"
+            }
+        },
+        {
+            "label": "PIO Monitor (DriverSample)",
+            "type": "shell",
+            "command": "platformio",
+            "args": [
+                "device",
+                "monitor",
+                "--project-dir",
+                "examples/DriverSample"
+            ],
+            "problemMatcher": []
+        }
+    ]
+}

--- a/examples/DriverSample/README.md
+++ b/examples/DriverSample/README.md
@@ -1,0 +1,35 @@
+# DriverSample Build Instructions
+
+This sample can now be built with either **Visual Micro** in Visual Studio or **PlatformIO** in Visual Studio Code.
+
+## Visual Micro (Visual Studio)
+
+1. Open `DriverSample.sln` in Visual Studio.
+2. Ensure the Visual Micro extension is installed and configured for your M5Stack board package.
+3. Build, upload and monitor the sketch using the Visual Micro tool windows as before. The existing project structure has not changed, so no additional configuration is required.
+
+## Visual Studio Code (PlatformIO)
+
+1. Install the [PlatformIO extension](https://platformio.org/install/ide?install=vscode) for Visual Studio Code (the repository now recommends it automatically).
+2. Open the repository folder in VS Code. The `examples/DriverSample/platformio.ini` file configures PlatformIO to build the sketch for the **M5Stack AtomS3**.
+3. Use one of the provided tasks (`Terminal` → `Run Task…`) or the PlatformIO sidebar buttons to:
+   - **Build**: `PIO Build (DriverSample)`
+   - **Upload**: `PIO Upload (DriverSample)`
+   - **Monitor**: `PIO Monitor (DriverSample)`
+4. All project-specific libraries are pulled from the local `Libraries` directory through `lib_extra_dirs`, so no additional package installation is necessary.
+
+### Command-line usage
+
+PlatformIO can also be invoked directly from a terminal:
+
+```sh
+platformio run --project-dir examples/DriverSample          # Build
+platformio run --target upload --project-dir examples/DriverSample  # Upload
+platformio device monitor --project-dir examples/DriverSample       # Serial monitor
+```
+
+## Notes
+
+- The sketch source continues to live in `DriverSample.ino` so Visual Micro compatibility is preserved.
+- When using PlatformIO, any build artifacts will be placed in `examples/DriverSample/.pio` (ignored by Git).
+- If you target a different board, adjust the `board` value inside `platformio.ini` accordingly.

--- a/examples/DriverSample/platformio.ini
+++ b/examples/DriverSample/platformio.ini
@@ -1,0 +1,12 @@
+[platformio]
+src_dir = .
+
+[env:m5stack-atoms3]
+platform = espressif32
+board = m5stack-atoms3
+framework = arduino
+monitor_speed = 115200
+lib_extra_dirs = Libraries
+build_flags =
+    -DARDUINO_USB_MODE=1
+    -DARDUINO_USB_CDC_ON_BOOT=1


### PR DESCRIPTION
## Summary
- add a PlatformIO configuration for the DriverSample sketch so it can be built from VS Code
- document how to work with both Visual Micro and PlatformIO, including command-line examples
- provide VS Code tasks and extension recommendation plus ignore PlatformIO build output

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e299c5fce88323b27fa7bcad30fb10